### PR TITLE
PR #1: Added IClient interface and descendants.

### DIFF
--- a/Edge.Modules.EventHandling/IClient.cs
+++ b/Edge.Modules.EventHandling/IClient.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RaaLabs.Edge.Modules.EventHandling
+{
+    public interface IClient
+    {
+        public Task Connect();
+    }
+
+    public interface IClient<ConnectionType> : IClient
+        where ConnectionType : IClientConnection
+    {
+    }
+
+    public interface IReceiverClient<ConnectionType, DataType> : IReceiverClient<DataType>, IClient<ConnectionType>
+        where ConnectionType : IClientConnection
+    {
+    }
+
+    public interface IReceiverClient<DataType> : IClient
+    {
+        public event DataReceivedDelegate<DataType> OnDataReceived;
+    }
+
+    public interface ISubscribingReceiverClient<DataType, TopicType> : IReceiverClient<DataType>
+    {
+        public Task Subscribe(TopicType topic);
+    }
+
+    public interface ISubscribingReceiverClient<ConnectionType, DataType, TopicType> : ISubscribingReceiverClient<DataType, TopicType>, IReceiverClient<ConnectionType, DataType>
+        where ConnectionType : IClientConnection
+    {
+    }
+
+    public delegate Task DataReceivedDelegate<DataType>(Type connectionType, DataType data);
+
+    public interface ISenderClient<ConnectionType, DataType> : ISenderClient<DataType>, IClient<ConnectionType>
+        where ConnectionType : IClientConnection
+    {
+    }
+
+    public interface ISenderClient<DataType> : IClient
+    {
+        public Task SendAsync(DataType data);
+    }
+
+    public interface IBatchedSenderClient<ConnectionType, DataType> : IBatchedSenderClient<DataType>, IClient<ConnectionType>
+        where ConnectionType : IClientConnection
+    {
+    }
+
+    public interface IBatchedSenderClient<DataType> : IClient
+    {
+        public Task SendBatchAsync(IEnumerable<DataType> data);
+    }
+
+
+    public interface IClientConnection { }
+}

--- a/Edge.Modules.EventHandling/IClient.cs
+++ b/Edge.Modules.EventHandling/IClient.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace RaaLabs.Edge.Modules.EventHandling
@@ -16,14 +14,16 @@ namespace RaaLabs.Edge.Modules.EventHandling
     {
     }
 
-    public interface IReceiverClient<ConnectionType, DataType> : IReceiverClient<DataType>, IClient<ConnectionType>
-        where ConnectionType : IClientConnection
-    {
-    }
-
     public interface IReceiverClient<DataType> : IClient
     {
         public event DataReceivedDelegate<DataType> OnDataReceived;
+    }
+
+    public delegate Task DataReceivedDelegate<DataType>(Type connectionType, DataType data);
+
+    public interface IReceiverClient<ConnectionType, DataType> : IReceiverClient<DataType>, IClient<ConnectionType>
+        where ConnectionType : IClientConnection
+    {
     }
 
     public interface ISubscribingReceiverClient<DataType, TopicType> : IReceiverClient<DataType>
@@ -36,19 +36,13 @@ namespace RaaLabs.Edge.Modules.EventHandling
     {
     }
 
-    public delegate Task DataReceivedDelegate<DataType>(Type connectionType, DataType data);
-
-    public interface ISenderClient<ConnectionType, DataType> : ISenderClient<DataType>, IClient<ConnectionType>
-        where ConnectionType : IClientConnection
-    {
-    }
 
     public interface ISenderClient<DataType> : IClient
     {
         public Task SendAsync(DataType data);
     }
 
-    public interface IBatchedSenderClient<ConnectionType, DataType> : IBatchedSenderClient<DataType>, IClient<ConnectionType>
+    public interface ISenderClient<ConnectionType, DataType> : ISenderClient<DataType>, IClient<ConnectionType>
         where ConnectionType : IClientConnection
     {
     }
@@ -58,6 +52,10 @@ namespace RaaLabs.Edge.Modules.EventHandling
         public Task SendBatchAsync(IEnumerable<DataType> data);
     }
 
+    public interface IBatchedSenderClient<ConnectionType, DataType> : IBatchedSenderClient<DataType>, IClient<ConnectionType>
+        where ConnectionType : IClientConnection
+    {
+    }
 
     public interface IClientConnection { }
 }


### PR DESCRIPTION
## Summary
This PR adds the `IClient` interface concept, as well as its descendants `IReceiverClient`, `ISubscribingReceiverClient` and `IProducerClient`. These interfaces will be used for creating clients to other systems, and they will also be used during testing.