### PR TITLE
PR #1: Split ibridge into incoming and outgoing

### DIFF
--- a/Edge.Modules.EventHandling/IBridge.cs
+++ b/Edge.Modules.EventHandling/IBridge.cs
@@ -10,4 +10,16 @@ namespace RaaLabs.Edge.Modules.EventHandling
     {
         public Task SetupBridge();
     }
+
+    public interface IBridgeIncomingEvent<T> : IBridge, IProduceEvent<T>
+    where T : IEvent
+    {
+
+    }
+
+    public interface IBridgeOutgoingEvent<T> : IBridge, IConsumeEvent<T>
+    where T : IEvent
+    {
+
+    }
 }


### PR DESCRIPTION
## Summary
The interface `IBridge` has now been split into `IBridgeIncomingEvent` and `IBridgeOutgoingEvent`. Bridges should implement these interfaces rather than `IBridge`, because these interfaces are automatically connected into the event handling system.