### PR TITLE
PR #2: Timescaledb module with IClient interface

### DIFF
--- a/Edge.Modules.Timescaledb/ITimescaledbClient.cs
+++ b/Edge.Modules.Timescaledb/ITimescaledbClient.cs
@@ -4,9 +4,12 @@ using RaaLabs.Edge.Modules.EventHandling;
 
 namespace RaaLabs.Edge.Modules.Timescaledb
 {
-    public interface ITimescaledbClient 
+    public interface ITimescaledbClient<ConnectionType> : ITimescaledbClient, ISenderClient<ConnectionType, object>
+        where ConnectionType : ITimescaledbConnection
     {
-        public Task SetupClient();
-        public Task IngestEventAsync<T>(T @event) where T: class;
+    }
+
+    public interface ITimescaledbClient : ISenderClient<object>
+    {
     }
 }

--- a/Edge.Modules.Timescaledb/ITimescaledbConnection.cs
+++ b/Edge.Modules.Timescaledb/ITimescaledbConnection.cs
@@ -1,0 +1,14 @@
+using RaaLabs.Edge.Modules.EventHandling;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RaaLabs.Edge.Modules.Timescaledb
+{
+    public interface ITimescaledbConnection : IClientConnection
+    {
+        public string ConnectionString { get; set; }
+    }
+}

--- a/Edge.Modules.Timescaledb/ITimescaledbEvent.cs
+++ b/Edge.Modules.Timescaledb/ITimescaledbEvent.cs
@@ -11,4 +11,18 @@ namespace RaaLabs.Edge.Modules.Timescaledb
     {
     }
 
+    /// <summary>
+    /// Attribute for the Timescaledb connection class. All classes implementing ITimescaleDbOutgoingEvent should use this annotation.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public class TimescaledbConnectionAttribute : Attribute
+    {
+        public Type Connection { get; }
+
+        public TimescaledbConnectionAttribute(Type connection)
+        {
+            Connection = connection;
+        }
+    }
+
 }

--- a/Edge.Modules.Timescaledb/Timescaledb.cs
+++ b/Edge.Modules.Timescaledb/Timescaledb.cs
@@ -11,8 +11,12 @@ namespace RaaLabs.Edge.Modules.Timescaledb
 
         protected override void Load(ContainerBuilder builder)
         {
+            builder.RegisterGeneric(typeof(TimescaledbClient<>))
+                .AsSelf()
+                .As(typeof(ITimescaledbClient<>))
+                .InstancePerRuntime();
+
             builder.RegisterType<TimescaledbBridge>().AsSelf().As<IBridge>().InstancePerMatchingLifetimeScope("runtime");
-            builder.RegisterType<TimescaledbClient>().AsSelf().As<ITimescaledbClient>().InstancePerMatchingLifetimeScope("runtime");
         }
     }
 }

--- a/Edge.Modules.Timescaledb/TimescaledbClient.cs
+++ b/Edge.Modules.Timescaledb/TimescaledbClient.cs
@@ -7,26 +7,56 @@ using System.Threading.Tasks;
 using Npgsql;
 using Dapper;
 using Dapper.Contrib.Extensions;
+using RaaLabs.Edge.Modules.EventHandling;
+using System.Collections.Generic;
 
 namespace RaaLabs.Edge.Modules.Timescaledb
 {
-    public class TimescaledbClient : ITimescaledbClient
+    public class TimescaledbClient<ConnectionType> : ITimescaledbClient<ConnectionType>
+        where ConnectionType : ITimescaledbConnection
     {
-        private static string timescaledbConnectionString = Environment.GetEnvironmentVariable("TIMESCALEDB_CONNECTION_STRING");
-        private NpgsqlConnection _client; 
+        private NpgsqlConnection _client;
+        private readonly ConnectionType _connection;
+        private readonly Dictionary<Type, Func<object, Task>> _ingestMethods = new();
 
-        public async Task SetupClient()
+        public TimescaledbClient(ConnectionType connection)
         {
-            _client = new NpgsqlConnection(timescaledbConnectionString);
+            _connection = connection;
+        }
+
+        public async Task Connect()
+        {
+            _client = new NpgsqlConnection(_connection.ConnectionString);
             await _client.OpenAsync();
         }
 
         public async Task IngestEventAsync<T>(T @event)
             where T: class
         {
-            IDbConnection clientConnection = _client; 
+            IDbConnection clientConnection = _client;
             clientConnection.Insert(@event);
             await Task.CompletedTask;
+        }
+
+        public async Task SendAsync(object data)
+        {
+            var dataType = data.GetType();
+            if (!_ingestMethods.TryGetValue(dataType, out Func<object, Task> ingestMethod))
+            {
+                ingestMethod = (Func<object, Task>)GetType().GetMethod("BuildIngestMethodForType", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).MakeGenericMethod(dataType).Invoke(this, Array.Empty<object>());
+                _ingestMethods.Add(dataType, ingestMethod);
+            }
+
+            await ingestMethod(data);
+        }
+
+        private Func<object, Task> BuildIngestMethodForType<T>()
+            where T : class
+        {
+            return async data =>
+            {
+                await _client.InsertAsync((T) data);
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary
Changes to the Timescaledb module to clean up the code and make it more easily testable
- the client implements `ISenderClient` interface for easy testing
- The `TimescaledbBridge` class now supports multiple timescaledb connections, one for each class implementing `ITimescaledbConnection`
- the client now holds a dictionary, `_ingestMethods`, which stores the ingestion method for a given function type. This saves us from having to invoke a function through reflection every time we want to ingest a data point.