### PR TITLE
Update ContextProvider.cs

### DIFF
--- a/Edge.Testing/ContextProvider.cs
+++ b/Edge.Testing/ContextProvider.cs
@@ -29,7 +29,7 @@ namespace RaaLabs.Edge.Testing
         /// <summary>
         /// 
         /// </summary>
-        [BeforeScenario(Order = 100)]
+        [BeforeScenario(Order = 100_000)]
         public void RegisterClassesFromAssemblies()
         {
             var allTypes = _assemblies.SelectMany(assembly => assembly.GetTypes()).ToList();


### PR DESCRIPTION
## Summary
Changed BeforeScenario order for automatic type registration from registered assemblies from 100 to 100 000. This is because the default order is 10 000, not 0, as was first assumed.